### PR TITLE
Fix Elasticsearch case

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Helm Monitor plugin
 ===================
 
 > Monitor a release, rollback to a previous version depending on the result of
-a PromQL (Prometheus), events (Sentry), Lucene or DSL query (ElasticSearch).
+a PromQL (Prometheus), events (Sentry), Lucene or DSL query (Elasticsearch).
 
 ![Helm monitor failure](helm-monitor-failure.png)
 
@@ -43,9 +43,9 @@ $ helm monitor prometheus --prometheus=http://prometheus:9090 \
     'rate(http_requests_total{code=~"^5.*$"}[5m]) > 0'
 ```
 
-### ElasticSearch
+### Elasticsearch
 
-Monitor the **peeking-bunny** release against an ElasticSearch server, a
+Monitor the **peeking-bunny** release against an Elasticsearch server, a
 rollback is initiated if the 5xx error rate is over 0 for the last minute.
 
 Using a Lucene query:
@@ -60,7 +60,7 @@ Using a query DSL file:
 $ helm monitor elasticsearch peeking-bunny ./query.json
 ```
 
-You can connect to a given ElasticSearch instance, by default it will connect to
+You can connect to a given Elasticsearch instance, by default it will connect to
 *http://localhost:9200*.
 
 ```bash

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -84,7 +84,7 @@ func newMonitorCmd(out io.Writer) *cobra.Command {
 
 	cmd.AddCommand(
 		newMonitorPrometheusCmd(out),
-		newMonitorElasticSearchCmd(out),
+		newMonitorElasticsearchCmd(out),
 		newMonitorSentryCmd(out),
 	)
 

--- a/cmd/monitor_elasticsearch.go
+++ b/cmd/monitor_elasticsearch.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/helm/pkg/helm"
 )
 
-const monitorElasticSearchDesc = `
-This command monitor a release by querying ElasticSearch at a given interval
+const monitorElasticsearchDesc = `
+This command monitor a release by querying Elasticsearch at a given interval
 and take care of rolling back to the previous version if the query return a non-
 empty result.
 
@@ -38,27 +38,27 @@ Reference:
 
 `
 
-type monitorElasticSearchCmd struct {
+type monitorElasticsearchCmd struct {
 	name              string
 	out               io.Writer
 	client            helm.Interface
-	elasticSearchAddr string
+	elasticsearchAddr string
 	query             string
 }
 
-type elasticSearchQueryResponse struct {
+type elasticsearchQueryResponse struct {
 	Count int64 `json:"count"`
 }
 
-func newMonitorElasticSearchCmd(out io.Writer) *cobra.Command {
-	m := &monitorElasticSearchCmd{
+func newMonitorElasticsearchCmd(out io.Writer) *cobra.Command {
+	m := &monitorElasticsearchCmd{
 		out: out,
 	}
 
 	cmd := &cobra.Command{
 		Use:     "elasticsearch [flags] RELEASE [QUERY DSL PATH|LUCENE QUERY]",
 		Short:   "query an elasticsearch server",
-		Long:    monitorElasticSearchDesc,
+		Long:    monitorElasticsearchDesc,
 		PreRunE: setupConnection,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
@@ -74,12 +74,12 @@ func newMonitorElasticSearchCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&m.elasticSearchAddr, "elasticsearch", "http://localhost:9200", "elasticsearch address")
+	f.StringVar(&m.elasticsearchAddr, "elasticsearch", "http://localhost:9200", "elasticsearch address")
 
 	return cmd
 }
 
-func (m *monitorElasticSearchCmd) run() error {
+func (m *monitorElasticsearchCmd) run() error {
 	_, err := m.client.ReleaseContent(m.name)
 	if err != nil {
 		return prettyError(err)
@@ -93,7 +93,7 @@ func (m *monitorElasticSearchCmd) run() error {
 
 	var req *http.Request
 	if err != nil {
-		req, err = http.NewRequest("GET", m.elasticSearchAddr+"/_count", nil)
+		req, err = http.NewRequest("GET", m.elasticsearchAddr+"/_count", nil)
 		if err != nil {
 			return prettyError(err)
 		}
@@ -102,7 +102,7 @@ func (m *monitorElasticSearchCmd) run() error {
 		q.Add("q", m.query)
 		req.URL.RawQuery = q.Encode()
 	} else {
-		req, err = http.NewRequest("GET", m.elasticSearchAddr+"/_count", queryBody)
+		req, err = http.NewRequest("GET", m.elasticsearchAddr+"/_count", queryBody)
 		if err != nil {
 			return prettyError(err)
 		}
@@ -140,7 +140,7 @@ func (m *monitorElasticSearchCmd) run() error {
 
 			fmt.Printf("Body: %s\n", string(body))
 
-			response := &elasticSearchQueryResponse{}
+			response := &elasticsearchQueryResponse{}
 			err = json.Unmarshal(body, response)
 			if err != nil {
 				return prettyError(err)

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,5 +27,5 @@ $ minikube service my-app
 ## Follow the monitoring procedure from the example below
 
 - [rollback based on Prometheus](prometheus.md)
-- [rollback based on ElasticSearch](elasticsearch.md)
+- [rollback based on Elasticsearch](elasticsearch.md)
 - [rollback based on Sentry](sentry.md)

--- a/examples/elasticsearch.md
+++ b/examples/elasticsearch.md
@@ -1,7 +1,7 @@
-Rollback based on an ElasticSearch query
+Rollback based on an Elasticsearch query
 ========================================
 
-> Use helm-monitor to rollback a release based on an ElasticSearch query
+> Use helm-monitor to rollback a release based on an Elasticsearch query
 
 ## Prepare
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,7 @@ name: "monitor"
 version: "0.4.0"
 usage: "monitor and rollback in case of failure based on metrics or logs"
 description: |-
-  Query at a given interval a Prometheus, ElasticSearch or Sentry instance. A
+  Query at a given interval a Prometheus, Elasticsearch or Sentry instance. A
   rollback of the release is initiated if the number of result is positive.
 ignoreFlags: false
 useTunnel: true


### PR DESCRIPTION
This change is a minor fix to correct the case of the word `Elasticsearch`.